### PR TITLE
feat(efs-access): on-demand EFS access helper for setup & testing

### DIFF
--- a/modules/efs-access/README.md
+++ b/modules/efs-access/README.md
@@ -1,0 +1,156 @@
+# efs-access
+
+An on-demand helper for reading and writing the persistence EFS volume from your laptop — for
+setup and testing — without weakening the file system's security model.
+
+The data EFS lives in private space behind an access point with IAM auth and transit encryption, so
+there is no direct path to it from a laptop. This module stands up a tiny, **stateless, default-off**
+helper instance that mounts the access point and exposes every practical transfer lane over AWS
+Systems Manager (SSM) — no bastion, no SSH key on a public port, no VPN.
+
+## On-demand by design ($0 idle)
+
+The helper is gated by `enabled` (default `false`). Because it is stateless — every byte of real data
+lives on EFS — it is **destroyed, not stopped**, when idle. A stopped instance still bills its EBS
+root volume; a destroyed one costs nothing. The IAM role, instance profile, and optional scratch
+bucket are always present (they are free); only the billable instance + volume toggle.
+
+```hcl
+# bring it up to seed/test
+enabled = true   # then: terraform apply   (~1-2 min to ready)
+
+# tear it down when done
+enabled = false  # then: terraform apply   ($0 idle)
+```
+
+This follows the NAT-free egress model of the `service` module: the helper gets a **public IP with no
+inbound rules** and reaches SSM over the existing internet gateway, so there is no always-on NAT
+gateway or interface-endpoint cost. With zero inbound rules and IMDSv2 enforced, the public IP is not
+a meaningful exposure — SSM remains outbound-only.
+
+## Transferring files
+
+Files land owned by the access point's `owner_uid`/`owner_gid` (default `1000:1000`) — the same
+identity the Fargate service runs as — so there is no ownership cleanup afterward.
+
+### Bulk seeds (multi-GB worlds, datasets) → `aws s3 sync` or `rsync`
+
+For anything large, use S3 as a transfer bus (set `create_transfer_bucket = true`). No SSH setup, and
+it is resumable and parallel:
+
+```bash
+# from your laptop
+aws s3 sync ./world s3://<transfer_bucket>/world/
+# then, in an SSM shell on the helper (see connect_command)
+aws s3 sync s3://<transfer_bucket>/world/ /mnt/data/world/
+```
+
+Or `rsync` straight to the helper over an SSM SSH tunnel (needs an entry in `ssh_authorized_keys` and
+the `session-manager-plugin` locally; see the tunnel setup below):
+
+```bash
+rsync -avP ./world efs-helper:/mnt/data/world/
+```
+
+### Poking at a few files → sshfs (FUSE-T) as a Finder drive, or an SFTP GUI
+
+For browsing or editing a handful of files, mount EFS as a local drive on macOS with
+[FUSE-T](https://www.fuse-t.org/) + sshfs (no kernel extension, no SIP changes) — or point a GUI
+client like Cyberduck/Transmit at the same SSM SSH tunnel. Lovely for convenience; not the path for a
+4 GB blob (sshfs-over-SSM will crawl on bulk transfers — use `aws s3 sync`/`rsync` for those).
+
+### SSH-over-SSM tunnel setup (for rsync / sshfs / SFTP lanes)
+
+Add to `~/.ssh/config`, then the lanes above can address the host as `efs-helper`:
+
+```
+Host efs-helper
+  HostName <instance_id>
+  User ec2-user
+  ProxyCommand sh -c "aws ssm start-session --target %h --document-name AWS-StartSSHSession --parameters portNumber=%p"
+```
+
+The simplest lane — an interactive shell, no keys required — is just the `connect_command` output:
+`aws ssm start-session --target <instance_id>`.
+
+## Example
+
+See [`examples/complete`](./examples/complete) for a full wiring of VPC + `persistence` + `efs-access`.
+
+<!-- BEGIN_TF_DOCS -->
+
+## Requirements
+
+| Name                                                                     | Version |
+| ------------------------------------------------------------------------ | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | ~> 6.32 |
+
+## Providers
+
+| Name                                             | Version |
+| ------------------------------------------------ | ------- |
+| <a name="provider_aws"></a> [aws](#provider_aws) | ~> 6.32 |
+
+## Modules
+
+| Name                                                                          | Source                                                         | Version |
+| ----------------------------------------------------------------------------- | -------------------------------------------------------------- | ------- |
+| <a name="module_label"></a> [label](#module_label)                            | git@github.com:bendoerr-terraform-modules/terraform-null-label | v1.0.0  |
+| <a name="module_label_transfer"></a> [label_transfer](#module_label_transfer) | git@github.com:bendoerr-terraform-modules/terraform-null-label | v1.0.0  |
+
+## Resources
+
+| Name                                                                                                                                                                                      | Type        |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [aws_iam_instance_profile.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile)                                                         | resource    |
+| [aws_iam_policy.transfer_rw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy)                                                                      | resource    |
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role)                                                                                 | resource    |
+| [aws_iam_role_policy_attachment.efs_rw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment)                                           | resource    |
+| [aws_iam_role_policy_attachment.ssm_core](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment)                                         | resource    |
+| [aws_iam_role_policy_attachment.transfer_rw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment)                                      | resource    |
+| [aws_instance.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance)                                                                                 | resource    |
+| [aws_s3_bucket.transfer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket)                                                                           | resource    |
+| [aws_s3_bucket_ownership_controls.transfer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls)                                     | resource    |
+| [aws_s3_bucket_public_access_block.transfer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block)                                   | resource    |
+| [aws_s3_bucket_server_side_encryption_configuration.transfer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource    |
+| [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)                                                 | data source |
+| [aws_iam_policy_document.transfer_rw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)                                                 | data source |
+| [aws_ssm_parameter.al2023](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter)                                                                  | data source |
+
+## Inputs
+
+| Name                                                                                                                     | Description                                                                                                                                                                                                                                                                                                                                                      | Type                                                                                                                                                                                                                                                                                                                      | Default       | Required |
+| ------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- | :------: |
+| <a name="input_context"></a> [context](#input_context)                                                                   | Shared Context from Ben's terraform-null-context                                                                                                                                                                                                                                                                                                                 | <pre>object({<br> attributes = list(string)<br> dns_namespace = string<br> environment = string<br> instance = string<br> instance_short = string<br> namespace = string<br> region = string<br> region_short = string<br> role = string<br> role_short = string<br> project = string<br> tags = map(string)<br> })</pre> | n/a           |   yes    |
+| <a name="input_access_point_id"></a> [access_point_id](#input_access_point_id)                                           | EFS access point ID to mount through, from the persistence module's access_point_id output. The access point enforces the POSIX owner_uid/owner_gid on every write.                                                                                                                                                                                              | `string`                                                                                                                                                                                                                                                                                                                  | n/a           |   yes    |
+| <a name="input_access_policy_arn"></a> [access_policy_arn](#input_access_policy_arn)                                     | IAM policy ARN granting EFS ClientMount/ClientWrite scoped to the access point, from the persistence module's access_policy_arn output. Attached to the helper's instance role for the iam mount option.                                                                                                                                                         | `string`                                                                                                                                                                                                                                                                                                                  | n/a           |   yes    |
+| <a name="input_access_security_group"></a> [access_security_group](#input_access_security_group)                         | Security group that permits NFS to the EFS mount targets, from the persistence module's access_security_group output. Attached to the helper so it can reach the file system; its all-egress rule also carries the SSM traffic.                                                                                                                                  | `string`                                                                                                                                                                                                                                                                                                                  | n/a           |   yes    |
+| <a name="input_file_system_id"></a> [file_system_id](#input_file_system_id)                                              | EFS file system ID to mount, from the persistence module's file_system_id output.                                                                                                                                                                                                                                                                                | `string`                                                                                                                                                                                                                                                                                                                  | n/a           |   yes    |
+| <a name="input_subnet_id"></a> [subnet_id](#input_subnet_id)                                                             | A PUBLIC subnet to place the helper in. This module follows the NAT-free egress model of the service module: the instance gets a public IP (no inbound rules) and reaches AWS Systems Manager over the existing internet gateway, avoiding an always-on NAT gateway or interface endpoints.                                                                      | `string`                                                                                                                                                                                                                                                                                                                  | n/a           |   yes    |
+| <a name="input_ami_id"></a> [ami_id](#input_ami_id)                                                                      | AMI ID for the helper. Defaults to the latest Amazon Linux 2023 arm64 AMI resolved from the public SSM parameter when null.                                                                                                                                                                                                                                      | `string`                                                                                                                                                                                                                                                                                                                  | `null`        |    no    |
+| <a name="input_assign_public_ip"></a> [assign_public_ip](#input_assign_public_ip)                                        | Assign a public IP so the SSM agent can reach Systems Manager over the internet gateway without a NAT gateway. Combined with zero inbound security-group rules and IMDSv2, the public IP is not a meaningful exposure because SSM remains outbound-only. Only set to false if the subnet already has SSM-reachable egress (NAT or interface endpoints).          | `bool`                                                                                                                                                                                                                                                                                                                    | `true`        |    no    |
+| <a name="input_create_transfer_bucket"></a> [create_transfer_bucket](#input_create_transfer_bucket)                      | Create a scratch S3 bucket for the aws s3 sync transfer lane and grant the helper read/write to it. When false, use your own bucket and attach S3 permissions yourself.                                                                                                                                                                                          | `bool`                                                                                                                                                                                                                                                                                                                    | `false`       |    no    |
+| <a name="input_enabled"></a> [enabled](#input_enabled)                                                                   | Whether the helper instance and its EBS volume exist. Defaults to false so the module costs $0 when idle. The IAM role, instance profile, and (optional) transfer bucket are always created since they are free; only the billable instance + volume are gated. Set to true and apply when you need to seed or inspect the volume, then back to false when done. | `bool`                                                                                                                                                                                                                                                                                                                    | `false`       |    no    |
+| <a name="input_instance_type"></a> [instance_type](#input_instance_type)                                                 | Instance type for the helper. Defaults to the cheapest current-gen Graviton (arm64) size; keep it arm64 to match the default AL2023 arm64 AMI.                                                                                                                                                                                                                   | `string`                                                                                                                                                                                                                                                                                                                  | `"t4g.nano"`  |    no    |
+| <a name="input_kms_ebs_arn"></a> [kms_ebs_arn](#input_kms_ebs_arn)                                                       | ARN of the KMS key for encrypting the root EBS volume. Defaults to the account's aws/ebs managed key when null.                                                                                                                                                                                                                                                  | `string`                                                                                                                                                                                                                                                                                                                  | `null`        |    no    |
+| <a name="input_mount_path"></a> [mount_path](#input_mount_path)                                                          | Path on the helper instance where the EFS access point is mounted.                                                                                                                                                                                                                                                                                               | `string`                                                                                                                                                                                                                                                                                                                  | `"/mnt/data"` |    no    |
+| <a name="input_owner_gid"></a> [owner_gid](#input_owner_gid)                                                             | POSIX GID the access point enforces on writes, from the persistence module's owner_gid output. Surfaced so operators know which GID will own seeded files.                                                                                                                                                                                                       | `number`                                                                                                                                                                                                                                                                                                                  | `1000`        |    no    |
+| <a name="input_owner_uid"></a> [owner_uid](#input_owner_uid)                                                             | POSIX UID the access point enforces on writes, from the persistence module's owner_uid output. Surfaced so operators know which UID will own seeded files.                                                                                                                                                                                                       | `number`                                                                                                                                                                                                                                                                                                                  | `1000`        |    no    |
+| <a name="input_root_volume_size"></a> [root_volume_size](#input_root_volume_size)                                        | Size in GiB of the encrypted gp3 root volume. The helper is stateless (all data lives on EFS), so this only needs to hold the OS.                                                                                                                                                                                                                                | `number`                                                                                                                                                                                                                                                                                                                  | `8`           |    no    |
+| <a name="input_ssh_authorized_keys"></a> [ssh_authorized_keys](#input_ssh_authorized_keys)                               | Public SSH keys to authorize for the ec2-user. Required only for the rsync / scp / sshfs (FUSE-T) / SFTP-over-SSM transfer lanes; the aws s3 sync lane and an interactive SSM shell need no keys.                                                                                                                                                                | `list(string)`                                                                                                                                                                                                                                                                                                            | `[]`          |    no    |
+| <a name="input_transfer_bucket_force_destroy"></a> [transfer_bucket_force_destroy](#input_transfer_bucket_force_destroy) | Allow terraform destroy to delete the scratch transfer bucket even if it still holds objects. Defaults to true because the bucket is staging-only scratch; set to false if you want destroy to refuse on a non-empty bucket.                                                                                                                                     | `bool`                                                                                                                                                                                                                                                                                                                    | `true`        |    no    |
+
+## Outputs
+
+| Name                                                                                   | Description                                                                            |
+| -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| <a name="output_connect_command"></a> [connect_command](#output_connect_command)       | Ready-to-run command to open an SSM shell on the helper, or null when disabled.        |
+| <a name="output_instance_id"></a> [instance_id](#output_instance_id)                   | ID of the helper instance, or null when enabled = false.                               |
+| <a name="output_instance_role_arn"></a> [instance_role_arn](#output_instance_role_arn) | ARN of the helper's instance role (carries SSM + EFS access).                          |
+| <a name="output_mount_path"></a> [mount_path](#output_mount_path)                      | Path on the helper where the EFS access point is mounted.                              |
+| <a name="output_owner_gid"></a> [owner_gid](#output_owner_gid)                         | POSIX GID the access point enforces on writes; seeded files will be owned by this GID. |
+| <a name="output_owner_uid"></a> [owner_uid](#output_owner_uid)                         | POSIX UID the access point enforces on writes; seeded files will be owned by this UID. |
+| <a name="output_transfer_bucket"></a> [transfer_bucket](#output_transfer_bucket)       | Name of the scratch transfer bucket, or null when create_transfer_bucket = false.      |
+
+<!-- END_TF_DOCS -->

--- a/modules/efs-access/README.md
+++ b/modules/efs-access/README.md
@@ -5,15 +5,16 @@ setup and testing — without weakening the file system's security model.
 
 The data EFS lives in private space behind an access point with IAM auth and transit encryption, so
 there is no direct path to it from a laptop. This module stands up a tiny, **stateless, default-off**
-helper instance that mounts the access point and exposes every practical transfer lane over AWS
-Systems Manager (SSM) — no bastion, no SSH key on a public port, no VPN.
+helper that mounts the access point and is reachable over AWS Systems Manager (SSM) — no bastion, no
+public SSH port, no VPN.
 
 ## On-demand by design ($0 idle)
 
 The helper is gated by `enabled` (default `false`). Because it is stateless — every byte of real data
 lives on EFS — it is **destroyed, not stopped**, when idle. A stopped instance still bills its EBS
-root volume; a destroyed one costs nothing. The IAM role, instance profile, and optional scratch
-bucket are always present (they are free); only the billable instance + volume toggle.
+root volume; a destroyed one costs nothing. The IAM role, instance profile, security group, and
+optional scratch bucket are always present (they are free); only the billable instance + volume
+toggle.
 
 ```hcl
 # bring it up to seed/test
@@ -24,44 +25,37 @@ enabled = false  # then: terraform apply   ($0 idle)
 ```
 
 This follows the NAT-free egress model of the `service` module: the helper gets a **public IP with no
-inbound rules** and reaches SSM over the existing internet gateway, so there is no always-on NAT
-gateway or interface-endpoint cost. With zero inbound rules and IMDSv2 enforced, the public IP is not
-a meaningful exposure — SSM remains outbound-only.
+inbound rules** plus an egress-only security group, and reaches SSM over the existing internet
+gateway — so there is no always-on NAT gateway or interface-endpoint cost. With zero inbound rules
+and IMDSv2 enforced, the public IP is not a meaningful exposure (SSM is outbound-only).
 
 ## Transferring files
 
 Files land owned by the access point's `owner_uid`/`owner_gid` (default `1000:1000`) — the same
-identity the Fargate service runs as — so there is no ownership cleanup afterward.
+identity the Fargate service runs as — so there is no ownership cleanup afterward. There are two
+first-class lanes:
 
-### Bulk seeds (multi-GB worlds, datasets) → `aws s3 sync` or `rsync`
+### 1. Bulk seeds (multi-GB worlds, datasets) → `aws s3 sync`
 
-For anything large, use S3 as a transfer bus (set `create_transfer_bucket = true`). No SSH setup, and
-it is resumable and parallel:
+Set `create_transfer_bucket = true` and use S3 as a transfer bus. No SSH setup, any OS, resumable:
 
 ```bash
 # from your laptop
 aws s3 sync ./world s3://<transfer_bucket>/world/
-# then, in an SSM shell on the helper (see connect_command)
+# then, in an SSM shell on the helper
 aws s3 sync s3://<transfer_bucket>/world/ /mnt/data/world/
 ```
 
-Or `rsync` straight to the helper over an SSM SSH tunnel (needs an entry in `ssh_authorized_keys` and
-the `session-manager-plugin` locally; see the tunnel setup below):
+### 2. The SSM SSH tunnel (interactive, and the base for any client)
+
+The zero-setup form is an interactive shell — no keys, just the `connect_command` output:
 
 ```bash
-rsync -avP ./world efs-helper:/mnt/data/world/
+aws ssm start-session --target <instance_id>
 ```
 
-### Poking at a few files → sshfs (FUSE-T) as a Finder drive, or an SFTP GUI
-
-For browsing or editing a handful of files, mount EFS as a local drive on macOS with
-[FUSE-T](https://www.fuse-t.org/) + sshfs (no kernel extension, no SIP changes) — or point a GUI
-client like Cyberduck/Transmit at the same SSM SSH tunnel. Lovely for convenience; not the path for a
-4 GB blob (sshfs-over-SSM will crawl on bulk transfers — use `aws s3 sync`/`rsync` for those).
-
-### SSH-over-SSM tunnel setup (for rsync / sshfs / SFTP lanes)
-
-Add to `~/.ssh/config`, then the lanes above can address the host as `efs-helper`:
+For file clients, add an SSH key to `ssh_authorized_keys` and put this in `~/.ssh/config` (needs the
+`session-manager-plugin` locally):
 
 ```
 Host efs-helper
@@ -70,8 +64,10 @@ Host efs-helper
   ProxyCommand sh -c "aws ssm start-session --target %h --document-name AWS-StartSSHSession --parameters portNumber=%p"
 ```
 
-The simplest lane — an interactive shell, no keys required — is just the `connect_command` output:
-`aws ssm start-session --target <instance_id>`.
+> **Layer your own client on the tunnel.** Once `efs-helper` resolves, point whatever you like at it:
+> `rsync -avP ./dir efs-helper:/mnt/data/`, an sshfs/[FUSE-T](https://www.fuse-t.org/) mount for a
+> Finder drive on macOS, or an SFTP GUI (Cyberduck/Transmit). Prefer `aws s3 sync` for multi-GB
+> transfers — sshfs-over-SSM is convenient for a few files, not fast for bulk.
 
 ## Example
 
@@ -97,6 +93,7 @@ See [`examples/complete`](./examples/complete) for a full wiring of VPC + `persi
 | Name                                                                          | Source                                                         | Version |
 | ----------------------------------------------------------------------------- | -------------------------------------------------------------- | ------- |
 | <a name="module_label"></a> [label](#module_label)                            | git@github.com:bendoerr-terraform-modules/terraform-null-label | v1.0.0  |
+| <a name="module_label_egress"></a> [label_egress](#module_label_egress)       | git@github.com:bendoerr-terraform-modules/terraform-null-label | v1.0.0  |
 | <a name="module_label_transfer"></a> [label_transfer](#module_label_transfer) | git@github.com:bendoerr-terraform-modules/terraform-null-label | v1.0.0  |
 
 ## Resources
@@ -114,9 +111,12 @@ See [`examples/complete`](./examples/complete) for a full wiring of VPC + `persi
 | [aws_s3_bucket_ownership_controls.transfer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls)                                     | resource    |
 | [aws_s3_bucket_public_access_block.transfer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block)                                   | resource    |
 | [aws_s3_bucket_server_side_encryption_configuration.transfer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource    |
+| [aws_security_group.egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group)                                                                   | resource    |
+| [aws_vpc_security_group_egress_rule.egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule)                                   | resource    |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)                                                 | data source |
 | [aws_iam_policy_document.transfer_rw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)                                                 | data source |
 | [aws_ssm_parameter.al2023](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter)                                                                  | data source |
+| [aws_subnet.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet)                                                                                  | data source |
 
 ## Inputs
 
@@ -125,7 +125,7 @@ See [`examples/complete`](./examples/complete) for a full wiring of VPC + `persi
 | <a name="input_context"></a> [context](#input_context)                                                                   | Shared Context from Ben's terraform-null-context                                                                                                                                                                                                                                                                                                                 | <pre>object({<br> attributes = list(string)<br> dns_namespace = string<br> environment = string<br> instance = string<br> instance_short = string<br> namespace = string<br> region = string<br> region_short = string<br> role = string<br> role_short = string<br> project = string<br> tags = map(string)<br> })</pre> | n/a           |   yes    |
 | <a name="input_access_point_id"></a> [access_point_id](#input_access_point_id)                                           | EFS access point ID to mount through, from the persistence module's access_point_id output. The access point enforces the POSIX owner_uid/owner_gid on every write.                                                                                                                                                                                              | `string`                                                                                                                                                                                                                                                                                                                  | n/a           |   yes    |
 | <a name="input_access_policy_arn"></a> [access_policy_arn](#input_access_policy_arn)                                     | IAM policy ARN granting EFS ClientMount/ClientWrite scoped to the access point, from the persistence module's access_policy_arn output. Attached to the helper's instance role for the iam mount option.                                                                                                                                                         | `string`                                                                                                                                                                                                                                                                                                                  | n/a           |   yes    |
-| <a name="input_access_security_group"></a> [access_security_group](#input_access_security_group)                         | Security group that permits NFS to the EFS mount targets, from the persistence module's access_security_group output. Attached to the helper so it can reach the file system; its all-egress rule also carries the SSM traffic.                                                                                                                                  | `string`                                                                                                                                                                                                                                                                                                                  | n/a           |   yes    |
+| <a name="input_access_security_group"></a> [access_security_group](#input_access_security_group)                         | Security group that permits NFS to the EFS mount targets, from the persistence module's access_security_group output. Attached to the helper so it can reach the file system. (SSM and package-mirror egress is carried by this module's own egress SG, since data_nfs only permits egress to its own members.)                                                  | `string`                                                                                                                                                                                                                                                                                                                  | n/a           |   yes    |
 | <a name="input_file_system_id"></a> [file_system_id](#input_file_system_id)                                              | EFS file system ID to mount, from the persistence module's file_system_id output.                                                                                                                                                                                                                                                                                | `string`                                                                                                                                                                                                                                                                                                                  | n/a           |   yes    |
 | <a name="input_subnet_id"></a> [subnet_id](#input_subnet_id)                                                             | A PUBLIC subnet to place the helper in. This module follows the NAT-free egress model of the service module: the instance gets a public IP (no inbound rules) and reaches AWS Systems Manager over the existing internet gateway, avoiding an always-on NAT gateway or interface endpoints.                                                                      | `string`                                                                                                                                                                                                                                                                                                                  | n/a           |   yes    |
 | <a name="input_ami_id"></a> [ami_id](#input_ami_id)                                                                      | AMI ID for the helper. Defaults to the latest Amazon Linux 2023 arm64 AMI resolved from the public SSM parameter when null.                                                                                                                                                                                                                                      | `string`                                                                                                                                                                                                                                                                                                                  | `null`        |    no    |
@@ -138,7 +138,7 @@ See [`examples/complete`](./examples/complete) for a full wiring of VPC + `persi
 | <a name="input_owner_gid"></a> [owner_gid](#input_owner_gid)                                                             | POSIX GID the access point enforces on writes, from the persistence module's owner_gid output. Surfaced so operators know which GID will own seeded files.                                                                                                                                                                                                       | `number`                                                                                                                                                                                                                                                                                                                  | `1000`        |    no    |
 | <a name="input_owner_uid"></a> [owner_uid](#input_owner_uid)                                                             | POSIX UID the access point enforces on writes, from the persistence module's owner_uid output. Surfaced so operators know which UID will own seeded files.                                                                                                                                                                                                       | `number`                                                                                                                                                                                                                                                                                                                  | `1000`        |    no    |
 | <a name="input_root_volume_size"></a> [root_volume_size](#input_root_volume_size)                                        | Size in GiB of the encrypted gp3 root volume. The helper is stateless (all data lives on EFS), so this only needs to hold the OS.                                                                                                                                                                                                                                | `number`                                                                                                                                                                                                                                                                                                                  | `8`           |    no    |
-| <a name="input_ssh_authorized_keys"></a> [ssh_authorized_keys](#input_ssh_authorized_keys)                               | Public SSH keys to authorize for the ec2-user. Required only for the rsync / scp / sshfs (FUSE-T) / SFTP-over-SSM transfer lanes; the aws s3 sync lane and an interactive SSM shell need no keys.                                                                                                                                                                | `list(string)`                                                                                                                                                                                                                                                                                                            | `[]`          |    no    |
+| <a name="input_ssh_authorized_keys"></a> [ssh_authorized_keys](#input_ssh_authorized_keys)                               | Public SSH keys to authorize for the ec2-user. Required only for the SSH-over-SSM file clients (rsync / sshfs / SFTP); the aws s3 sync lane and an interactive SSM shell need no keys.                                                                                                                                                                           | `list(string)`                                                                                                                                                                                                                                                                                                            | `[]`          |    no    |
 | <a name="input_transfer_bucket_force_destroy"></a> [transfer_bucket_force_destroy](#input_transfer_bucket_force_destroy) | Allow terraform destroy to delete the scratch transfer bucket even if it still holds objects. Defaults to true because the bucket is staging-only scratch; set to false if you want destroy to refuse on a non-empty bucket.                                                                                                                                     | `bool`                                                                                                                                                                                                                                                                                                                    | `true`        |    no    |
 
 ## Outputs

--- a/modules/efs-access/examples/complete/ctx.tf
+++ b/modules/efs-access/examples/complete/ctx.tf
@@ -1,0 +1,12 @@
+variable "namespace" {
+  type = string
+}
+
+module "context" {
+  source      = "git@github.com:bendoerr-terraform-modules/terraform-null-context?ref=v0.4.0"
+  namespace   = var.namespace
+  environment = "testing"
+  role        = "development"
+  region      = "us-east-1"
+  project     = "efs-access"
+}

--- a/modules/efs-access/examples/complete/efs_access_complete.tf
+++ b/modules/efs-access/examples/complete/efs_access_complete.tf
@@ -1,3 +1,15 @@
+variable "efs_access_enabled" {
+  type        = bool
+  default     = false
+  description = "Bring the helper instance up in this example. Defaults to false so a casual apply stays cost-safe; set true to exercise the running helper."
+}
+
+variable "create_transfer_bucket" {
+  type        = bool
+  default     = false
+  description = "Create the scratch transfer bucket in this example. Defaults to false to keep a casual apply cost-safe."
+}
+
 module "fod_persistence" {
   source     = "../../../persistence"
   context    = module.context.shared
@@ -7,7 +19,7 @@ module "fod_persistence" {
 module "fod_efs_access" {
   source  = "../.."
   context = module.context.shared
-  enabled = true
+  enabled = var.efs_access_enabled
 
   subnet_id             = module.vpc.public_subnets[0]
   file_system_id        = module.fod_persistence.file_system_id
@@ -17,7 +29,7 @@ module "fod_efs_access" {
   owner_uid             = module.fod_persistence.owner_uid
   owner_gid             = module.fod_persistence.owner_gid
 
-  create_transfer_bucket = true
+  create_transfer_bucket = var.create_transfer_bucket
 }
 
 output "instance_id" {

--- a/modules/efs-access/examples/complete/efs_access_complete.tf
+++ b/modules/efs-access/examples/complete/efs_access_complete.tf
@@ -1,0 +1,41 @@
+module "fod_persistence" {
+  source     = "../../../persistence"
+  context    = module.context.shared
+  subnet_ids = module.vpc.public_subnets
+}
+
+module "fod_efs_access" {
+  source  = "../.."
+  context = module.context.shared
+  enabled = true
+
+  subnet_id             = module.vpc.public_subnets[0]
+  file_system_id        = module.fod_persistence.file_system_id
+  access_point_id       = module.fod_persistence.access_point_id
+  access_security_group = module.fod_persistence.access_security_group
+  access_policy_arn     = module.fod_persistence.access_policy_arn
+  owner_uid             = module.fod_persistence.owner_uid
+  owner_gid             = module.fod_persistence.owner_gid
+
+  create_transfer_bucket = true
+}
+
+output "instance_id" {
+  value       = module.fod_efs_access.instance_id
+  description = "ID of the helper instance."
+}
+
+output "connect_command" {
+  value       = module.fod_efs_access.connect_command
+  description = "Command to open an SSM shell on the helper."
+}
+
+output "mount_path" {
+  value       = module.fod_efs_access.mount_path
+  description = "Path on the helper where EFS is mounted."
+}
+
+output "transfer_bucket" {
+  value       = module.fod_efs_access.transfer_bucket
+  description = "Name of the scratch transfer bucket."
+}

--- a/modules/efs-access/examples/complete/versions.tf
+++ b/modules/efs-access/examples/complete/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+# AWS Provider Configuration
+provider "aws" {
+  region = "us-east-1"
+}

--- a/modules/efs-access/examples/complete/vpc.tf
+++ b/modules/efs-access/examples/complete/vpc.tf
@@ -1,0 +1,19 @@
+module "label_network" {
+  source  = "git@github.com:bendoerr-terraform-modules/terraform-null-label?ref=v0.4.0"
+  context = module.context.shared
+  name    = "ntwrk"
+}
+
+module "vpc" {
+  source     = "terraform-aws-modules/vpc/aws"
+  version    = "5.1.1"
+  create_vpc = true
+
+  name = module.label_network.id
+
+  cidr           = "10.10.0.0/16"
+  azs            = ["us-east-1a", "us-east-1b"]
+  public_subnets = ["10.10.1.0/24", "10.10.2.0/24"]
+
+  enable_nat_gateway = false
+}

--- a/modules/efs-access/main.tf
+++ b/modules/efs-access/main.tf
@@ -1,0 +1,179 @@
+module "label" {
+  source  = "git@github.com:bendoerr-terraform-modules/terraform-null-label?ref=v1.0.0"
+  context = var.context
+  name    = "efs-acc"
+}
+
+locals {
+  enabled = var.enabled ? 1 : 0
+  ami_id  = var.ami_id != null ? var.ami_id : nonsensitive(data.aws_ssm_parameter.al2023.value)
+
+  user_data = templatefile("${path.module}/user-data.sh.tftpl", {
+    mount_path          = var.mount_path
+    file_system_id      = var.file_system_id
+    access_point_id     = var.access_point_id
+    ssh_authorized_keys = var.ssh_authorized_keys
+  })
+}
+
+# Latest Amazon Linux 2023 arm64 AMI, published by AWS as a public SSM parameter.
+data "aws_ssm_parameter" "al2023" {
+  name = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64"
+}
+
+# ---------------------------------------------------------------------------
+# Instance role + profile. Always created (IAM is free); only the instance and
+# its EBS volume are gated by var.enabled so idle cost stays at $0.
+# ---------------------------------------------------------------------------
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "this" {
+  name               = module.label.id
+  tags               = module.label.tags
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+# Interactive shell + the SSH-over-SSM tunnel used by every transfer lane.
+resource "aws_iam_role_policy_attachment" "ssm_core" {
+  role       = aws_iam_role.this.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+# EFS ClientMount/ClientWrite, already scoped to the access point by persistence.
+resource "aws_iam_role_policy_attachment" "efs_rw" {
+  role       = aws_iam_role.this.name
+  policy_arn = var.access_policy_arn
+}
+
+resource "aws_iam_instance_profile" "this" {
+  name = module.label.id
+  tags = module.label.tags
+  role = aws_iam_role.this.name
+}
+
+# ---------------------------------------------------------------------------
+# Optional scratch bucket for the `aws s3 sync` transfer lane.
+# ---------------------------------------------------------------------------
+module "label_transfer" {
+  source  = "git@github.com:bendoerr-terraform-modules/terraform-null-label?ref=v1.0.0"
+  context = var.context
+  name    = "efs-acc-xfer"
+}
+
+# A staging-only scratch bucket: encrypted, fully public-access-blocked, owner
+# enforced. Versioning and access logging are intentionally omitted because the
+# bucket is transient (force_destroy) and holds nothing of record.
+# tfsec:ignore:aws-s3-enable-versioning
+# tfsec:ignore:aws-s3-enable-bucket-logging
+# tfsec:ignore:aws-s3-encryption-customer-key
+resource "aws_s3_bucket" "transfer" {
+  count         = var.create_transfer_bucket ? 1 : 0
+  bucket        = module.label_transfer.id
+  tags          = module.label_transfer.tags
+  force_destroy = var.transfer_bucket_force_destroy
+}
+
+resource "aws_s3_bucket_public_access_block" "transfer" {
+  count                   = var.create_transfer_bucket ? 1 : 0
+  bucket                  = aws_s3_bucket.transfer[0].id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "transfer" {
+  count  = var.create_transfer_bucket ? 1 : 0
+  bucket = aws_s3_bucket.transfer[0].id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_ownership_controls" "transfer" {
+  count  = var.create_transfer_bucket ? 1 : 0
+  bucket = aws_s3_bucket.transfer[0].id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+data "aws_iam_policy_document" "transfer_rw" {
+  count = var.create_transfer_bucket ? 1 : 0
+  statement {
+    effect  = "Allow"
+    actions = ["s3:ListBucket"]
+    resources = [
+      aws_s3_bucket.transfer[0].arn,
+    ]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+    resources = [
+      "${aws_s3_bucket.transfer[0].arn}/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "transfer_rw" {
+  count  = var.create_transfer_bucket ? 1 : 0
+  name   = module.label_transfer.id
+  tags   = module.label_transfer.tags
+  policy = data.aws_iam_policy_document.transfer_rw[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "transfer_rw" {
+  count      = var.create_transfer_bucket ? 1 : 0
+  role       = aws_iam_role.this.name
+  policy_arn = aws_iam_policy.transfer_rw[0].arn
+}
+
+# ---------------------------------------------------------------------------
+# The helper itself. Gated by var.enabled -> destroy, don't stop, for true $0
+# idle (a stopped instance still bills its EBS volume).
+# ---------------------------------------------------------------------------
+# A public IP is required so the SSM agent can reach Systems Manager over the
+# existing internet gateway (this VPC runs NAT-free, matching the service module).
+# With zero inbound rules and IMDSv2 enforced, SSM stays outbound-only.
+# tfsec:ignore:aws-ec2-no-public-ip
+resource "aws_instance" "this" {
+  count = local.enabled
+
+  ami                         = local.ami_id
+  instance_type               = var.instance_type
+  subnet_id                   = var.subnet_id
+  associate_public_ip_address = var.assign_public_ip
+  vpc_security_group_ids      = [var.access_security_group]
+  iam_instance_profile        = aws_iam_instance_profile.this.name
+  user_data                   = local.user_data
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
+  root_block_device {
+    encrypted   = true
+    volume_type = "gp3"
+    volume_size = var.root_volume_size
+    kms_key_id  = var.kms_ebs_arn
+  }
+
+  tags = module.label.tags
+}

--- a/modules/efs-access/main.tf
+++ b/modules/efs-access/main.tf
@@ -71,10 +71,10 @@ module "label_transfer" {
 
 # A staging-only scratch bucket: encrypted, fully public-access-blocked, owner
 # enforced. Versioning and access logging are intentionally omitted because the
-# bucket is transient (force_destroy) and holds nothing of record.
-# tfsec:ignore:aws-s3-enable-versioning
-# tfsec:ignore:aws-s3-enable-bucket-logging
-# tfsec:ignore:aws-s3-encryption-customer-key
+# bucket is transient (force_destroy) and holds nothing of record, so access
+# logging and versioning add no value on this scratch storage.
+# trivy:ignore:AVD-AWS-0089
+# trivy:ignore:AVD-AWS-0090
 resource "aws_s3_bucket" "transfer" {
   count         = var.create_transfer_bucket ? 1 : 0
   bucket        = module.label_transfer.id
@@ -91,6 +91,10 @@ resource "aws_s3_bucket_public_access_block" "transfer" {
   restrict_public_buckets = true
 }
 
+# SSE-S3 (AES256), not a customer-managed KMS key: a CMK costs ~$1/mo just to
+# exist, which would break this module's $0-idle goal for a transient scratch
+# bucket. SSE-S3 is the appropriate, free choice here.
+# trivy:ignore:AVD-AWS-0132
 resource "aws_s3_bucket_server_side_encryption_configuration" "transfer" {
   count  = var.create_transfer_bucket ? 1 : 0
   bucket = aws_s3_bucket.transfer[0].id
@@ -150,8 +154,9 @@ resource "aws_iam_role_policy_attachment" "transfer_rw" {
 # ---------------------------------------------------------------------------
 # A public IP is required so the SSM agent can reach Systems Manager over the
 # existing internet gateway (this VPC runs NAT-free, matching the service module).
-# With zero inbound rules and IMDSv2 enforced, SSM stays outbound-only.
-# tfsec:ignore:aws-ec2-no-public-ip
+# With zero inbound rules and IMDSv2 enforced, SSM stays outbound-only, so the
+# public IP (required for SSM egress in this NAT-free VPC) is not an exposure.
+# trivy:ignore:AVD-AWS-0009
 resource "aws_instance" "this" {
   count = local.enabled
 

--- a/modules/efs-access/main.tf
+++ b/modules/efs-access/main.tf
@@ -151,6 +151,42 @@ resource "aws_iam_role_policy_attachment" "transfer_rw" {
 }
 
 # ---------------------------------------------------------------------------
+# Egress security group. The persistence data_nfs SG only permits egress to its
+# own members (the mount targets), so the helper needs its own outbound rule to
+# reach the SSM endpoints and the package mirrors. No ingress -- SSM is
+# outbound-only. Always created (an empty SG is free) so idle cost stays at $0.
+# ---------------------------------------------------------------------------
+data "aws_subnet" "this" {
+  id = var.subnet_id
+}
+
+module "label_egress" {
+  source  = "git@github.com:bendoerr-terraform-modules/terraform-null-label?ref=v1.0.0"
+  context = var.context
+  name    = "efs-acc-egr"
+}
+
+resource "aws_security_group" "egress" {
+  name        = module.label_egress.id
+  tags        = module.label_egress.tags
+  vpc_id      = data.aws_subnet.this.vpc_id
+  description = "efs-access helper outbound for SSM + package install; no inbound"
+}
+
+# Unrestricted egress: an SSM-managed helper must reach the SSM endpoints and the
+# AL2023 package mirrors, whose IPs span large, shifting AWS ranges -- the same
+# outbound posture the service module uses. There are zero inbound rules, so the
+# box cannot be reached from outside.
+# trivy:ignore:AVD-AWS-0104
+resource "aws_vpc_security_group_egress_rule" "egress" {
+  security_group_id = aws_security_group.egress.id
+  tags              = module.label_egress.tags
+  description       = "All outbound for SSM registration and package install"
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = -1
+}
+
+# ---------------------------------------------------------------------------
 # The helper itself. Gated by var.enabled -> destroy, don't stop, for true $0
 # idle (a stopped instance still bills its EBS volume).
 # ---------------------------------------------------------------------------
@@ -166,7 +202,7 @@ resource "aws_instance" "this" {
   instance_type               = var.instance_type
   subnet_id                   = var.subnet_id
   associate_public_ip_address = var.assign_public_ip
-  vpc_security_group_ids      = [var.access_security_group]
+  vpc_security_group_ids      = [var.access_security_group, aws_security_group.egress.id]
   iam_instance_profile        = aws_iam_instance_profile.this.name
   user_data                   = local.user_data
 

--- a/modules/efs-access/main.tf
+++ b/modules/efs-access/main.tf
@@ -6,7 +6,7 @@ module "label" {
 
 locals {
   enabled = var.enabled ? 1 : 0
-  ami_id  = var.ami_id != null ? var.ami_id : nonsensitive(data.aws_ssm_parameter.al2023.value)
+  ami_id  = var.ami_id != null ? var.ami_id : nonsensitive(data.aws_ssm_parameter.al2023[0].value)
 
   user_data = templatefile("${path.module}/user-data.sh.tftpl", {
     mount_path          = var.mount_path
@@ -17,8 +17,10 @@ locals {
 }
 
 # Latest Amazon Linux 2023 arm64 AMI, published by AWS as a public SSM parameter.
+# Skipped entirely when the caller supplies an explicit ami_id.
 data "aws_ssm_parameter" "al2023" {
-  name = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64"
+  count = var.ami_id == null ? 1 : 0
+  name  = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64"
 }
 
 # ---------------------------------------------------------------------------

--- a/modules/efs-access/outputs.tf
+++ b/modules/efs-access/outputs.tf
@@ -1,0 +1,34 @@
+output "instance_id" {
+  value       = try(aws_instance.this[0].id, null)
+  description = "ID of the helper instance, or null when enabled = false."
+}
+
+output "mount_path" {
+  value       = var.mount_path
+  description = "Path on the helper where the EFS access point is mounted."
+}
+
+output "instance_role_arn" {
+  value       = aws_iam_role.this.arn
+  description = "ARN of the helper's instance role (carries SSM + EFS access)."
+}
+
+output "connect_command" {
+  value       = try("aws ssm start-session --target ${aws_instance.this[0].id}", null)
+  description = "Ready-to-run command to open an SSM shell on the helper, or null when disabled."
+}
+
+output "transfer_bucket" {
+  value       = try(aws_s3_bucket.transfer[0].bucket, null)
+  description = "Name of the scratch transfer bucket, or null when create_transfer_bucket = false."
+}
+
+output "owner_uid" {
+  value       = var.owner_uid
+  description = "POSIX UID the access point enforces on writes; seeded files will be owned by this UID."
+}
+
+output "owner_gid" {
+  value       = var.owner_gid
+  description = "POSIX GID the access point enforces on writes; seeded files will be owned by this GID."
+}

--- a/modules/efs-access/user-data.sh.tftpl
+++ b/modules/efs-access/user-data.sh.tftpl
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install the EFS mount helper (amazon-efs-utils) so we can mount the access point
+# with TLS + IAM auth -- the same secure path the Fargate service uses.
+dnf install -y amazon-efs-utils
+
+# Mount the EFS access point. The access point roots the mount and enforces its
+# POSIX owner_uid/owner_gid, so files seeded here are owned the way the service expects.
+mkdir -p ${mount_path}
+mount -t efs -o tls,iam,accesspoint=${access_point_id} ${file_system_id}:/ ${mount_path}
+
+# Persist the mount across reboots.
+echo "${file_system_id}:/ ${mount_path} efs _netdev,tls,iam,accesspoint=${access_point_id} 0 0" >> /etc/fstab
+
+%{ if length(ssh_authorized_keys) > 0 ~}
+# Authorize keys for the rsync / scp / sshfs (FUSE-T) / SFTP-over-SSM transfer lanes.
+install -d -m 700 -o ec2-user -g ec2-user /home/ec2-user/.ssh
+%{ for key in ssh_authorized_keys ~}
+echo "${key}" >> /home/ec2-user/.ssh/authorized_keys
+%{ endfor ~}
+chmod 600 /home/ec2-user/.ssh/authorized_keys
+chown ec2-user:ec2-user /home/ec2-user/.ssh/authorized_keys
+%{ endif ~}

--- a/modules/efs-access/variables.tf
+++ b/modules/efs-access/variables.tf
@@ -45,7 +45,7 @@ variable "access_point_id" {
 
 variable "access_security_group" {
   type        = string
-  description = "Security group that permits NFS to the EFS mount targets, from the persistence module's access_security_group output. Attached to the helper so it can reach the file system; its all-egress rule also carries the SSM traffic."
+  description = "Security group that permits NFS to the EFS mount targets, from the persistence module's access_security_group output. Attached to the helper so it can reach the file system. (SSM and package-mirror egress is carried by this module's own egress SG, since data_nfs only permits egress to its own members.)"
 }
 
 variable "access_policy_arn" {

--- a/modules/efs-access/variables.tf
+++ b/modules/efs-access/variables.tf
@@ -1,0 +1,114 @@
+variable "context" {
+  type = object({
+    attributes     = list(string)
+    dns_namespace  = string
+    environment    = string
+    instance       = string
+    instance_short = string
+    namespace      = string
+    region         = string
+    region_short   = string
+    role           = string
+    role_short     = string
+    project        = string
+    tags           = map(string)
+  })
+  description = "Shared Context from Ben's terraform-null-context"
+}
+
+variable "enabled" {
+  type        = bool
+  default     = false
+  description = "Whether the helper instance and its EBS volume exist. Defaults to false so the module costs $0 when idle. The IAM role, instance profile, and (optional) transfer bucket are always created since they are free; only the billable instance + volume are gated. Set to true and apply when you need to seed or inspect the volume, then back to false when done."
+}
+
+variable "subnet_id" {
+  type        = string
+  description = "A PUBLIC subnet to place the helper in. This module follows the NAT-free egress model of the service module: the instance gets a public IP (no inbound rules) and reaches AWS Systems Manager over the existing internet gateway, avoiding an always-on NAT gateway or interface endpoints."
+}
+
+variable "assign_public_ip" {
+  type        = bool
+  default     = true
+  description = "Assign a public IP so the SSM agent can reach Systems Manager over the internet gateway without a NAT gateway. Combined with zero inbound security-group rules and IMDSv2, the public IP is not a meaningful exposure because SSM remains outbound-only. Only set to false if the subnet already has SSM-reachable egress (NAT or interface endpoints)."
+}
+
+variable "file_system_id" {
+  type        = string
+  description = "EFS file system ID to mount, from the persistence module's file_system_id output."
+}
+
+variable "access_point_id" {
+  type        = string
+  description = "EFS access point ID to mount through, from the persistence module's access_point_id output. The access point enforces the POSIX owner_uid/owner_gid on every write."
+}
+
+variable "access_security_group" {
+  type        = string
+  description = "Security group that permits NFS to the EFS mount targets, from the persistence module's access_security_group output. Attached to the helper so it can reach the file system; its all-egress rule also carries the SSM traffic."
+}
+
+variable "access_policy_arn" {
+  type        = string
+  description = "IAM policy ARN granting EFS ClientMount/ClientWrite scoped to the access point, from the persistence module's access_policy_arn output. Attached to the helper's instance role for the iam mount option."
+}
+
+variable "mount_path" {
+  type        = string
+  default     = "/mnt/data"
+  description = "Path on the helper instance where the EFS access point is mounted."
+}
+
+variable "instance_type" {
+  type        = string
+  default     = "t4g.nano"
+  description = "Instance type for the helper. Defaults to the cheapest current-gen Graviton (arm64) size; keep it arm64 to match the default AL2023 arm64 AMI."
+}
+
+variable "root_volume_size" {
+  type        = number
+  default     = 8
+  description = "Size in GiB of the encrypted gp3 root volume. The helper is stateless (all data lives on EFS), so this only needs to hold the OS."
+}
+
+variable "ssh_authorized_keys" {
+  type        = list(string)
+  default     = []
+  description = "Public SSH keys to authorize for the ec2-user. Required only for the rsync / scp / sshfs (FUSE-T) / SFTP-over-SSM transfer lanes; the aws s3 sync lane and an interactive SSM shell need no keys."
+}
+
+variable "kms_ebs_arn" {
+  type        = string
+  default     = null
+  description = "ARN of the KMS key for encrypting the root EBS volume. Defaults to the account's aws/ebs managed key when null."
+}
+
+variable "owner_uid" {
+  type        = number
+  default     = 1000
+  description = "POSIX UID the access point enforces on writes, from the persistence module's owner_uid output. Surfaced so operators know which UID will own seeded files."
+}
+
+variable "owner_gid" {
+  type        = number
+  default     = 1000
+  description = "POSIX GID the access point enforces on writes, from the persistence module's owner_gid output. Surfaced so operators know which GID will own seeded files."
+}
+
+variable "ami_id" {
+  type        = string
+  default     = null
+  description = "AMI ID for the helper. Defaults to the latest Amazon Linux 2023 arm64 AMI resolved from the public SSM parameter when null."
+}
+
+variable "create_transfer_bucket" {
+  type        = bool
+  default     = false
+  description = "Create a scratch S3 bucket for the aws s3 sync transfer lane and grant the helper read/write to it. When false, use your own bucket and attach S3 permissions yourself."
+}
+
+variable "transfer_bucket_force_destroy" {
+  type        = bool
+  default     = true
+  description = "Allow terraform destroy to delete the scratch transfer bucket even if it still holds objects. Defaults to true because the bucket is staging-only scratch; set to false if you want destroy to refuse on a non-empty bucket."
+}

--- a/modules/efs-access/versions.tf
+++ b/modules/efs-access/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.32"
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds `modules/efs-access` — an on-demand helper for reading and writing the `persistence` EFS volume from a laptop, for **setup and testing**, without weakening the file system's security model.

The data EFS lives in private space behind an access point with IAM auth and transit encryption, so there's no direct path to it from a laptop. This module stands up a tiny, **stateless, default-off** helper that mounts the access point and exposes every practical transfer lane over SSM — no bastion, no public SSH port, no VPN.

Implements the design proposed and reviewed in #237.

## Design highlights

- **True $0 idle.** Gated by `enabled` (default `false`). Because the helper is stateless (all data lives on EFS) it is **destroyed, not stopped** — a *stopped* instance still bills its EBS root volume, a destroyed one costs nothing. The IAM role, instance profile, and optional scratch bucket are always present (free); only the billable instance + volume toggle.
- **NAT-free egress (the review blocker, fixed).** The helper goes in a **public subnet with a public IP, zero inbound rules, IMDSv2 enforced**, and reaches Systems Manager over the existing internet gateway — exactly the model `modules/service` already uses. No always-on NAT gateway or interface endpoints, so the $0-idle claim holds. With no inbound rules and SSM outbound-only, the public IP is not a meaningful exposure.
- **Reuses the persistence security model.** Attaches persistence's `data_nfs` SG and its access-point-scoped IAM policy; mounts via `amazon-efs-utils` with `tls,iam,accesspoint=…`, so seeded files are owned by the access point's enforced `owner_uid`/`owner_gid` — no ownership cleanup.
- **Transfer lanes.** Bulk seeds → `aws s3 sync` (optional scratch bucket, `force_destroy`) or `rsync`; poking at a few files → sshfs/FUSE-T Finder mount or an SFTP GUI, both over the SSM SSH tunnel. README has copy-paste recipes and steers multi-GB transfers at S3/rsync rather than the Finder mount.

## Usage

```hcl
module "fod_efs_access" {
  source  = "../../modules/efs-access"
  context = module.context.shared
  enabled = true # flip to false + apply to tear down to $0

  subnet_id             = module.vpc.public_subnets[0]
  file_system_id        = module.persistence.file_system_id
  access_point_id       = module.persistence.access_point_id
  access_security_group = module.persistence.access_security_group
  access_policy_arn     = module.persistence.access_policy_arn
  owner_uid             = module.persistence.owner_uid
  owner_gid             = module.persistence.owner_gid

  create_transfer_bucket = true
  ssh_authorized_keys    = ["ssh-ed25519 AAAA... me@laptop"] # only for rsync/sshfs/SFTP lanes
}
```

## Testing

- `terraform fmt`, `tflint` (preset `all`, aws plugin), and `trivy config` all pass locally on the module and `examples/complete`.
- Intentionally **not** added to the `test.yml` terratest matrix — that does a live apply against the sandbox account (real $ per CI run). Happy to add live coverage behind a `workflow_dispatch` trigger as a follow-up if wanted.

## Follow-ups (out of scope here)

- Custodian-style auto-destroy-on-idle (reusing the launcher/watchdog pattern), so the helper tears itself down — proposed as a fast-follow, not gated on this PR.

cc @oldmanbendobot — folds in your review notes from #237 (public-subnet egress fix, uid/gid passthrough, headline the right transfer lane for bulk, `force_destroy` on the scratch bucket). Ready for a proper look.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Introduced an `efs-access` Terraform module that provisions an on-demand EC2 helper to mount an EFS access point.
- Provides Systems Manager–based connectivity without requiring inbound SSH/VPN access.
- Optionally creates an encrypted scratch S3 bucket to support S3 transfer workflows.
- Added a complete, conditional end-to-end Terraform example (VPC + module wiring) with helpful outputs.

## Documentation
- Added comprehensive module documentation, including connection guidance and detailed input/output reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->