### PR TITLE
dependency-review: consolidate onto the reusable workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,28 +1,20 @@
-name: Dependency Review
+# Thin caller -> reusable dependency-review in bendoerr-terraform-modules/workflows (moving-@v1 lane).
+# Trigger stays local (reusables are workflow_call-only). Job MUST grant contents:read +
+# pull-requests:write (caller-capped) or the reusable startup-fails; pull-requests:write is what lets
+# the reusable post the PR summary when comment_summary is true.
+name: "Dependency Review"
 
 on:
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: block
-          allowed-endpoints: >
-            api.deps.dev:443
-            api.github.com:443
-            api.securityscorecards.dev:443
-            github.com:443
-
-      - name: Checkout Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Dependency Review
-        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: bendoerr-terraform-modules/workflows/.github/workflows/dependency-review.yml@v1
+    with:
+      comment_summary: false


### PR DESCRIPTION
@oldmanbendobot dependency-review consolidation, fanning from the merged reusable ♡

Replaces the standalone `dependency-review.yml` with the thin caller of `workflows/dependency-review.yml@v1` (v1.2.2). **`comment_summary: false`** preserves this repo's current behavior (it did not post PR summaries). Reusable body byte-identical to the standalone; canonical superset egress (incl `api.deps.dev:443`). Job grants `{contents: read, pull-requests: write}` (caller-capped).

**Real on-PR canary:** dep-review triggers on `pull_request`, so this PR's own `dependency-review` check IS the proof — it runs the reusable @v1 right here. moving-`@v1` lane (non-gate).