### PR TITLE
🔧 (deps): watch example pins too, matching the org standard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,9 @@
 version: 2
 updates:
   - package-ecosystem: "terraform"
-    directory: "/modules/persistence"
+    directories:
+      - "/modules/persistence"
+      - "/modules/persistence/examples/complete"
     schedule:
       interval: "weekly"
     groups:
@@ -17,7 +19,9 @@ updates:
       default-days: 14
 
   - package-ecosystem: "terraform"
-    directory: "/modules/launcher"
+    directories:
+      - "/modules/launcher"
+      - "/modules/launcher/examples/complete"
     schedule:
       interval: "weekly"
     groups:
@@ -32,7 +36,9 @@ updates:
       default-days: 14
 
   - package-ecosystem: "terraform"
-    directory: "/modules/notice-discord"
+    directories:
+      - "/modules/notice-discord"
+      - "/modules/notice-discord/examples/complete"
     schedule:
       interval: "weekly"
     groups:
@@ -47,7 +53,9 @@ updates:
       default-days: 14
 
   - package-ecosystem: "terraform"
-    directory: "/modules/dns-record"
+    directories:
+      - "/modules/dns-record"
+      - "/modules/dns-record/examples/complete"
     schedule:
       interval: "weekly"
     groups:
@@ -62,7 +70,9 @@ updates:
       default-days: 14
 
   - package-ecosystem: "terraform"
-    directory: "/modules/efs-access"
+    directories:
+      - "/modules/efs-access"
+      - "/modules/efs-access/examples/complete"
     schedule:
       interval: "weekly"
     groups:
@@ -77,7 +87,9 @@ updates:
       default-days: 14
 
   - package-ecosystem: "terraform"
-    directory: "/modules/notice-github"
+    directories:
+      - "/modules/notice-github"
+      - "/modules/notice-github/examples/complete"
     schedule:
       interval: "weekly"
     groups:
@@ -92,7 +104,9 @@ updates:
       default-days: 14
 
   - package-ecosystem: "terraform"
-    directory: "/modules/notice-parameter-store"
+    directories:
+      - "/modules/notice-parameter-store"
+      - "/modules/notice-parameter-store/examples/complete"
     schedule:
       interval: "weekly"
     groups:
@@ -107,7 +121,9 @@ updates:
       default-days: 14
 
   - package-ecosystem: "terraform"
-    directory: "/modules/service"
+    directories:
+      - "/modules/service"
+      - "/modules/service/examples/complete"
     schedule:
       interval: "weekly"
     groups:

--- a/.github/scripts/coverage-truth.py
+++ b/.github/scripts/coverage-truth.py
@@ -67,6 +67,13 @@ if not modules:
 testdirs = sorted(
     m for m in modules if os.path.isdir(os.path.join(mdir, m, "test"))
 )
+# Terratest applies against examples/complete, so an unwatched example pin is a
+# real coverage hole: CI's only live apply would exercise a dependency the module
+# under test no longer uses. Derived from disk, never hand-listed.
+exampledirs = sorted(
+    m for m in modules
+    if os.path.isdir(os.path.join(mdir, m, "examples", "complete"))
+)
 
 test_wf = load_yaml(".github/workflows/test.yml")
 try:
@@ -155,7 +162,19 @@ def exempted(module, arm):
 
 # Arms ----------------------------------------------------------------------
 want_test_entries = {f"modules/{m}/test" for m in testdirs}
-want_tf = {f"/modules/{m}" for m in modules if not exempted(m, "dependabot")}
+want_tf = (
+    {f"/modules/{m}" for m in modules if not exempted(m, "dependabot")}
+    | {f"/modules/{m}/examples/complete"
+       for m in exampledirs if not exempted(m, "dependabot")}
+)
+# What a terraform entry is ALLOWED to point at. Deliberately a roster check and
+# not a bare os.path.isdir: "/modules/x/test" is on disk and is still a terraform
+# misconfiguration. The existence guard on examples/complete keeps the disk half
+# real, so an entry naming a directory that is gone still REDs.
+allowed_tf = (
+    {f"/modules/{m}" for m in modules}
+    | {f"/modules/{m}/examples/complete" for m in exampledirs}
+)
 want_go = {f"/modules/{m}/test" for m in testdirs if not exempted(m, "dependabot")}
 have_matrix = set(matrix)
 have_wd = set(workdirs)
@@ -174,6 +193,8 @@ for m, arms_set in sorted(exempt.items()):
     if "golangci" in arms_set and f"modules/{m}/test" in have_wd:
         stale.append(f"exemption '{m}:golangci' is stale: the workdir entry exists")
     if "dependabot" in arms_set and f"/modules/{m}" in tf_dirs and (
+        m not in exampledirs or f"/modules/{m}/examples/complete" in tf_dirs
+    ) and (
         m not in testdirs or f"/modules/{m}/test" in go_dirs
     ):
         stale.append(f"exemption '{m}:dependabot' is stale: the dependabot entries exist")
@@ -192,8 +213,9 @@ arms = {
     ),
     "dependabot": (
         [f"{d} has no terraform dependabot entry" for d in sorted(want_tf - tf_dirs)]
-        + [f"{d} is in dependabot(terraform) but not on disk"
-           for d in sorted(tf_dirs - {f'/modules/{m}' for m in modules})]
+        + [f"{d} is in dependabot(terraform) but is neither a module root nor an "
+            f"examples/complete that exists on disk"
+           for d in sorted(tf_dirs - allowed_tf)]
         + [f"{d} has no gomod dependabot entry" for d in sorted(want_go - go_dirs)]
         + [f"{d} is in dependabot(gomod) but not on disk"
            for d in sorted(go_dirs - {f'/modules/{m}/test' for m in testdirs})]
@@ -222,6 +244,7 @@ for name, violations in arms.items():
 
 print(
     f"population: {len(modules)} modules, {len(testdirs)} test dirs, "
+    f"{len(exampledirs)} examples/complete, "
     f"{sum(len(v) for v in exempt.values())} exemptions"
 )
 if red:


### PR DESCRIPTION
## what

The eight `terraform` update entries scan `/modules/<name>` only. Dependabot doesn't recurse, so **every pin under `modules/*/examples/complete/` has been outside dependency updates since this repo was created**. This adds each module's `examples/complete` as a second scan directory on the same entry.

## the drift it's been hiding

Measured on `9218673` — **18 unwatched pins**:

- `terraform-null-label` — v0.4.0 ×9, v0.4.1 ×1 &nbsp;→&nbsp; modules are on **v1.0.1** (a full major behind)
- `terraform-null-context` — v0.4.0 ×8 &nbsp;→&nbsp; current is **v0.5.2**

`null-context` appears *nowhere else in the repo*, so it has never been bumped by anything, by anyone.

**This isn't cosmetic.** Six terratest suites do `terraformFolderRelativeToRoot := "examples/complete"` — the only real `terraform apply` in CI exercises a context/label a major behind the module under test. Version skew is untested in precisely the direction that matters.

## receipts

| claim | measurement |
|---|---|
| examples are unwatched | `git log -- 'modules/*/examples/*'` → **0** dependabot commits, whole history |
| ...and the query could have seen them | positive control: same query on `modules/*/main.tf` → **27** dependabot commits |
| this config shape works | `terraform-aws-cloudfront-and-s3-origin` already uses `directories` with an examples path; its dependabot commits read *"Bump the terraform group across 2 directories"* and **do** touch `examples/` (`75275b2`, `cfe9f34`) |

So it's your own org standard — fod is just the repo that never got it, probably because it's the only multi-module one.

## verification on the diff

- 8 terraform entries → 8 `directories:` blocks, **16** scan dirs
- every added path asserted to **exist on disk** before the edit was written
- `gomod` (`/modules/*/test`) and `github-actions` (`/`) entries **byte-identical** — asserted, not eyeballed
- `yaml.safe_load` parses

## what it will actually do to your inbox 👀

Next weekly run, expect **~8 grouped PRs** — one per module, since each entry keeps its single `terraform` group so a module and its example bump together instead of separately. `cooldown: default-days: 14` still applies.

Several will be **major** bumps (null-label v0.4.0 → v1.0.1), which #577 just made group properly — so this lands in the right order, not before it. Those will need real review: a major null-label can change generated names, and terratest applies real resources. That's the safety net doing its job, but it's your call whether you want that wave now or after the coverage-truth dust settles.

your button, your repo — i just noticed the hole while watching #577's grouping actually fire on #580 and couldn't leave it alone (≖ᴗ≖✿)